### PR TITLE
Handle external sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ This prints the login details and current meter readings.
 
 ## Configuration
 
-* **Reuse `aiohttp.ClientSession`**: Pass an existing session (e.g., from Home Assistant) to `BControl` to take advantage of connection pooling.
+* **Reuse `aiohttp.ClientSession`**: Pass an existing session (e.g., from Home Assistant) to `BControl` to take advantage of connection pooling. An external session will **not** be closed by `BControl.close()`.
 * **Handle Exceptions**: Catch `AuthenticationError` to trigger re-authentication flows.
 * **Customize Mapping**: The OBIS code mapping resides in `key_mapping.py` and can be extended for additional measurements.
 

--- a/src/bcontrolpy/bcontrolpy.py
+++ b/src/bcontrolpy/bcontrolpy.py
@@ -73,9 +73,27 @@ def translate_keys(data: dict, mapping: dict) -> dict:
 
 class BControl:
     def __init__(self, ip: str, password: str, session: aiohttp.ClientSession = None):
+        """Initialize the client.
+
+        Parameters
+        ----------
+        ip: str
+            IP address of the B-Control meter.
+        password: str
+            Password used for authentication.
+        session: aiohttp.ClientSession, optional
+            Reuse an existing session. If omitted, ``BControl`` creates its
+            own ``ClientSession`` which will be closed on :meth:`close`.
+        """
+
         self.base_url = f"http://{ip}"
         self.password = password
-        self.session = session or aiohttp.ClientSession()
+        if session is None:
+            self.session = aiohttp.ClientSession()
+            self._session_owner = True
+        else:
+            self.session = session
+            self._session_owner = False
         self.cookie_value = None
         self.logged_in = False
         self.serial = None
@@ -135,4 +153,6 @@ class BControl:
         return translate_keys(data, key_mapping)
 
     async def close(self):
-        await self.session.close()
+        """Close the underlying :class:`aiohttp.ClientSession` if owned."""
+        if self._session_owner:
+            await self.session.close()

--- a/tests/test_bcontrol.py
+++ b/tests/test_bcontrol.py
@@ -97,3 +97,13 @@ async def test_missing_cookie(session):
               headers={})
         with pytest.raises(CookieValueError):
             await bc.login()
+
+
+@pytest.mark.asyncio
+async def test_external_session_not_closed(session):
+    """Ensure `BControl.close()` doesn't close externally supplied sessions."""
+    bc = BControl(ip="127.0.0.1", password="secret", session=session)
+
+    # close without performing any network interactions
+    await bc.close()
+    assert not session.closed


### PR DESCRIPTION
## Summary
- track if BControl created the aiohttp ClientSession
- only close internally created sessions
- document session reuse behavior
- add test that external session is not closed
- add missing newline at EOF

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ccded5bb4832ea1d40b469e2bad18